### PR TITLE
Prevent Using CoreTelephony API on Simulator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change Log
 
 ## [Unreleased]
+* [#10](https://github.com/Blackjacx/Columbus/pull/10): Prevent Using CoreTelephony API on Simulator - [@blackjacx](https://github.com/blackjacx).
 
 ## [0.7.0] - 2018-12-24
 * [#9](https://github.com/Blackjacx/Columbus/pull/9): Enable Carthage Support - [@blackjacx](https://github.com/blackjacx).

--- a/Source/Classes/CountryPickerViewController.swift
+++ b/Source/Classes/CountryPickerViewController.swift
@@ -7,7 +7,8 @@
 //
 
 import UIKit
-#if os(iOS)
+
+#if os(iOS) && !targetEnvironment(simulator)
 import CoreTelephony
 #endif
 
@@ -153,7 +154,7 @@ public final class CountryPickerViewController: UIViewController {
 
         // Core Telephony Approach
 
-        #if os(iOS)
+        #if os(iOS) && !targetEnvironment(simulator)
         if
             let simRegionId = CTTelephonyNetworkInfo().subscriberCellularProvider?.isoCountryCode,
             let country = (countries.first { $0.isoCountryCode.compare(simRegionId, options: .caseInsensitive) == .orderedSame }) {


### PR DESCRIPTION
In a different app that uses Columbus suddenly hundrets of warnings
appeared at runtime in the console. These where due to determining the
default country on the simulator which uses the CoreTelephony API that
is not available on the simulator.