### PR TITLE
Remove CFBundleExecutable From Plist

### DIFF
--- a/Source/Resources/Info.plist
+++ b/Source/Resources/Info.plist
@@ -4,8 +4,6 @@
 <dict>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
-	<key>CFBundleExecutable</key>
-	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
 	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>


### PR DESCRIPTION
### Due to this error message

"Unexpected CFBundleExecutable Key. The bundle at 'Payload/ioki.app/Frameworks/Columbus.framework/Resources.bundle' does not contain a bundle executable. If this bundle intentionally does not contain an executable, consider removing the CFBundleExecutable key from its Info.plist and using a CFBundlePackageType of BNDL. If this bundle is part of a third-party framework, consider contacting the developer of the framework for an update to address this issue."