### PR TITLE
Fix Recursive Textfield Determination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change Log
 
 ## [Unreleased]
+* [#18](https://github.com/Blackjacx/Columbus/pull/18): Fix Recursive Textfield Determination - [@Blackjacx](https://github.com/Blackjacx).
 * Fix vulnerability with Fastlane / mini_magick - [@Blackjacx](https://github.com/blackjacx).
 
 ## [1.0.0] - 2019-05-14

--- a/Columbus.xcodeproj/project.pbxproj
+++ b/Columbus.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		B905891D230233B800491105 /* UIView+Subviews.swift in Sources */ = {isa = PBXBuildFile; fileRef = B905891C230233B800491105 /* UIView+Subviews.swift */; };
+		B905891E230233BC00491105 /* UIView+Subviews.swift in Sources */ = {isa = PBXBuildFile; fileRef = B905891C230233B800491105 /* UIView+Subviews.swift */; };
 		B94B1AF921CD38B400FF1B72 /* Country.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9F8788F21CD28EC00273F82 /* Country.swift */; };
 		B94B1AFA21CD38B400FF1B72 /* CountryList.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9F8788E21CD28EC00273F82 /* CountryList.swift */; };
 		B94B1AFB21CD38B400FF1B72 /* Configuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9F8789421CD28EC00273F82 /* Configuration.swift */; };
@@ -65,6 +67,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		B905891C230233B800491105 /* UIView+Subviews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+Subviews.swift"; sourceTree = "<group>"; };
 		B94B1B0621CD38B400FF1B72 /* Columbus.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Columbus.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		B96D496221CD3DC20010E69B /* Resources.bundle */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = Resources.bundle; sourceTree = BUILT_PRODUCTS_DIR; };
 		B9A4A65921D0FC14001FF5DC /* ColumbusTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColumbusTests.swift; sourceTree = "<group>"; };
@@ -223,6 +226,7 @@
 				B9F8788E21CD28EC00273F82 /* CountryList.swift */,
 				B9F8789221CD28EC00273F82 /* CountryPickerViewController.swift */,
 				B9F8789121CD28EC00273F82 /* CountryView.swift */,
+				B905891C230233B800491105 /* UIView+Subviews.swift */,
 			);
 			path = Classes;
 			sourceTree = "<group>";
@@ -474,6 +478,7 @@
 				B94B1AFA21CD38B400FF1B72 /* CountryList.swift in Sources */,
 				B94B1AFB21CD38B400FF1B72 /* Configuration.swift in Sources */,
 				B94B1AFC21CD38B400FF1B72 /* CountryCell.swift in Sources */,
+				B905891E230233BC00491105 /* UIView+Subviews.swift in Sources */,
 				B94B1AFD21CD38B400FF1B72 /* CountryPickerViewController.swift in Sources */,
 				B94B1AFE21CD38B400FF1B72 /* Columbus.swift in Sources */,
 				B94B1AFF21CD38B400FF1B72 /* CountryView.swift in Sources */,
@@ -510,6 +515,7 @@
 				B9F8789C21CD28EC00273F82 /* CountryList.swift in Sources */,
 				B9F878A221CD28EC00273F82 /* Configuration.swift in Sources */,
 				B9F878A121CD28EC00273F82 /* CountryCell.swift in Sources */,
+				B905891D230233B800491105 /* UIView+Subviews.swift in Sources */,
 				B9F878A021CD28EC00273F82 /* CountryPickerViewController.swift in Sources */,
 				B9F8789E21CD28EC00273F82 /* Columbus.swift in Sources */,
 				B9F8789F21CD28EC00273F82 /* CountryView.swift in Sources */,

--- a/Source/Classes/Columbus.swift
+++ b/Source/Classes/Columbus.swift
@@ -22,4 +22,8 @@ public final class Columbus {
         }
         return bundle
     }()
+
+    static func layoutConstraintId(_ suffix: String) -> String {
+        return "\(Columbus.bundle.bundleIdentifier!).\(suffix)"
+    }
 }

--- a/Source/Classes/CountryCell.swift
+++ b/Source/Classes/CountryCell.swift
@@ -10,7 +10,7 @@ import UIKit
 
 final class CountryCell: UITableViewCell {
 
-    static let cellId = "CountryCell"
+    static var cellId: String { return "\(CountryCell.self)" }
 
     var countryView = CountryView()
 
@@ -54,13 +54,19 @@ final class CountryCell: UITableViewCell {
     func setupLayoutConstraints() {
         let raster = Columbus.config.rasterSize
 
-        NSLayoutConstraint.activate([
-            countryView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: raster),
-            countryView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -raster),
-            countryView.topAnchor.constraint(equalTo: contentView.topAnchor, constant: raster),
-            countryView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -raster),
-            ]
-        )
+        let leading = countryView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: raster)
+        leading.identifier = Columbus.layoutConstraintId("\(type(of: self)).leading")
+
+        let trailing = countryView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -raster)
+        trailing.identifier = Columbus.layoutConstraintId("\(type(of: self)).trailing")
+
+        let top = countryView.topAnchor.constraint(equalTo: contentView.topAnchor, constant: raster)
+        top.identifier = Columbus.layoutConstraintId("\(type(of: self)).top")
+
+        let bottom = countryView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -raster)
+        bottom.identifier = Columbus.layoutConstraintId("\(type(of: self)).bottom")
+
+        NSLayoutConstraint.activate([leading, trailing, top, bottom])
     }
 
     func configure(with country: Country) {

--- a/Source/Classes/UIView+Subviews.swift
+++ b/Source/Classes/UIView+Subviews.swift
@@ -1,0 +1,20 @@
+//
+//  UIView+Subviews.swift
+//  Columbus
+//
+//  Created by Stefan Herold on 13.08.19.
+//  Copyright © 2019 CodingCobra. All rights reserved.
+//
+
+import UIKit
+
+extension UIView {
+
+    func recursiveSubviews() -> [UIView] {
+
+        if subviews.isEmpty {
+            return subviews
+        }
+        return subviews + subviews.flatMap { $0.recursiveSubviews() }
+    }
+}


### PR DESCRIPTION
The text field could not be determined in iOS 13 anymore. Apple added an
API specifically for that which is used now. All of this remains
compatible with Xcode 10 and Swift 5.

All constraints now have identifiers to be able to find layout problems
much easier.