### PR TITLE
Use region code instead Locale in defaultCountry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change Log
 
 ## [Unreleased]
+* [#23](https://github.com/Blackjacx/Columbus/pull/23): Use region code instead Locale in defaultCountry - [@Blackjacx](https://github.com/Blackjacx).
 
 ## [1.2.0] - 2020-04-16
 * [#22](https://github.com/Blackjacx/Columbus/pull/22): Enable module stability - [@Blackjacx](https://github.com/Blackjacx).

--- a/Example/Source/AppDelegate.swift
+++ b/Example/Source/AppDelegate.swift
@@ -20,8 +20,9 @@ final class AppDelegate: UIResponder, UIApplicationDelegate {
         window = UIWindow(frame: UIScreen.main.bounds)
 
         Columbus.config = CountryPickerConfig()
+        let defaultCountry = CountryPickerViewController.defaultCountry(from: "US")
 
-        let countryPicker = CountryPickerViewController(initialRegionCode: "DE", didSelectClosure: { (country) in
+        let countryPicker = CountryPickerViewController(initialCountryCode: defaultCountry.isoCountryCode, didSelectClosure: { (country) in
             print(country)
         })
         window?.rootViewController = countryPicker


### PR DESCRIPTION
### Use region code instead Locale in defaultCountry

Locale was kind of overkill as we only need the isoRegionCode to
determine the default country. It also enables persisting this code for
apps that e.g. use the country picker at login time. The persisted
code can then be used to re-initialize a phone number view controller
with an existing number when the user wants to edit it.

Apart from this i streamlined the wording to `isoCountryCode` when
referring to the two-letter [ISO 3166](https://en.wikipedia.org/wiki/List_of_ISO_3166_country_codes)
code of a country.