### PR TITLE
Remove defaultCountry() isoCountryCode param default value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change Log
 
 ## [Unreleased]
+* [#24](https://github.com/Blackjacx/Columbus/pull/24): Remove defaultCountry() isoCountryCode param default value - [@Blackjacx](https://github.com/Blackjacx).
 
 ## [1.4.0] - 2020-07-02
 * [#23](https://github.com/Blackjacx/Columbus/pull/23): Use region code instead Locale in defaultCountry - [@Blackjacx](https://github.com/Blackjacx).


### PR DESCRIPTION
The default value was problematic since it was not possible to force a specific country in defaultCountry by specifying a region code when you run the code on a device with SIM card. Now it works 👍