### PR TITLE
XCFramework Compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change Log
 
 ## [Unreleased]
+* [#34](https://github.com/Blackjacx/Columbus/pull/34): XCFramework Compatibility - [@Blackjacx](https://github.com/Blackjacx).
 * Simplify section index creation - [@Blackjacx](https://github.com/Blackjacx).
 * Throw error instead of ignore missing flag icon - [@Blackjacx](https://github.com/Blackjacx).
 

--- a/Columbus.podspec
+++ b/Columbus.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
     s.author            = { 'Stefan Herold' => 'stefan.herold@gmail.com' }
     s.source            = { :git => 'https://github.com/blackjacx/Columbus.git', :tag => s.version.to_s }
     s.source_files = 'Source/Classes/**/*'
-    s.swift_versions = ['5.3']
+    s.swift_versions = ['5.4']
 
     s.ios.deployment_target = '11.0'
     s.tvos.deployment_target = '11.0'
@@ -21,9 +21,5 @@ Pod::Spec.new do |s|
     }
 
     s.frameworks = 'UIKit'
-
-    # s.dependency 'AFNetworking', '~> 2.3'
-    # s.screenshots     = 'www.example.com/screenshots_1', 'www.example.com/screenshots_2'
-    # s.public_header_files = 'Pod/Classes/**/*.h'
 end
 

--- a/Columbus.xcodeproj/project.pbxproj
+++ b/Columbus.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 52;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -20,7 +20,7 @@
 		B94B1AFB21CD38B400FF1B72 /* Configurable.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9F8789421CD28EC00273F82 /* Configurable.swift */; };
 		B94B1AFC21CD38B400FF1B72 /* CountryCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9F8789321CD28EC00273F82 /* CountryCell.swift */; };
 		B94B1AFD21CD38B400FF1B72 /* CountryPickerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9F8789221CD28EC00273F82 /* CountryPickerViewController.swift */; };
-		B94B1AFE21CD38B400FF1B72 /* Columbus.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9F8789021CD28EC00273F82 /* Columbus.swift */; };
+		B94B1AFE21CD38B400FF1B72 /* ColumbusMain.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9F8789021CD28EC00273F82 /* ColumbusMain.swift */; };
 		B94B1AFF21CD38B400FF1B72 /* CountryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9F8789121CD28EC00273F82 /* CountryView.swift */; };
 		B96D495D21CD3DC20010E69B /* Countries.json in Resources */ = {isa = PBXBuildFile; fileRef = B9F8789721CD28EC00273F82 /* Countries.json */; };
 		B96D495E21CD3DC20010E69B /* Flags.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B9F8789821CD28EC00273F82 /* Flags.xcassets */; };
@@ -35,7 +35,7 @@
 		B9DB66ED21DF924600E9BB35 /* Columbus.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B94B1B0621CD38B400FF1B72 /* Columbus.framework */; };
 		B9F8789C21CD28EC00273F82 /* CountryList.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9F8788E21CD28EC00273F82 /* CountryList.swift */; };
 		B9F8789D21CD28EC00273F82 /* Country.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9F8788F21CD28EC00273F82 /* Country.swift */; };
-		B9F8789E21CD28EC00273F82 /* Columbus.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9F8789021CD28EC00273F82 /* Columbus.swift */; };
+		B9F8789E21CD28EC00273F82 /* ColumbusMain.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9F8789021CD28EC00273F82 /* ColumbusMain.swift */; };
 		B9F8789F21CD28EC00273F82 /* CountryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9F8789121CD28EC00273F82 /* CountryView.swift */; };
 		B9F878A021CD28EC00273F82 /* CountryPickerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9F8789221CD28EC00273F82 /* CountryPickerViewController.swift */; };
 		B9F878A121CD28EC00273F82 /* CountryCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9F8789321CD28EC00273F82 /* CountryCell.swift */; };
@@ -94,7 +94,7 @@
 		B9F8788321CD28A200273F82 /* Columbus.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Columbus.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		B9F8788E21CD28EC00273F82 /* CountryList.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CountryList.swift; sourceTree = "<group>"; };
 		B9F8788F21CD28EC00273F82 /* Country.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Country.swift; sourceTree = "<group>"; };
-		B9F8789021CD28EC00273F82 /* Columbus.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Columbus.swift; sourceTree = "<group>"; };
+		B9F8789021CD28EC00273F82 /* ColumbusMain.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ColumbusMain.swift; sourceTree = "<group>"; };
 		B9F8789121CD28EC00273F82 /* CountryView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CountryView.swift; sourceTree = "<group>"; };
 		B9F8789221CD28EC00273F82 /* CountryPickerViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CountryPickerViewController.swift; sourceTree = "<group>"; };
 		B9F8789321CD28EC00273F82 /* CountryCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CountryCell.swift; sourceTree = "<group>"; };
@@ -231,7 +231,7 @@
 		B9F8788C21CD28EC00273F82 /* Classes */ = {
 			isa = PBXGroup;
 			children = (
-				B9F8789021CD28EC00273F82 /* Columbus.swift */,
+				B9F8789021CD28EC00273F82 /* ColumbusMain.swift */,
 				B9F8789421CD28EC00273F82 /* Configurable.swift */,
 				B9F8788F21CD28EC00273F82 /* Country.swift */,
 				B9CAAB1325E1BEB4004BA1BF /* EmptyDecodable.swift */,
@@ -394,7 +394,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 1010;
-				LastUpgradeCheck = 1240;
+				LastUpgradeCheck = 1250;
 				ORGANIZATIONNAME = "Stefan Herold";
 				TargetAttributes = {
 					B94B1AF421CD38B400FF1B72 = {
@@ -414,7 +414,7 @@
 				};
 			};
 			buildConfigurationList = 607FACCB1AFB9204008FA782 /* Build configuration list for PBXProject "Columbus" */;
-			compatibilityVersion = "Xcode 11.0";
+			compatibilityVersion = "Xcode 12.0";
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
@@ -541,7 +541,7 @@
 				B933818825CDD4F200618FFD /* CountryPickerViewController+DisplayState.swift in Sources */,
 				B93D76E723E4A66600E41863 /* CustomSearchBar.swift in Sources */,
 				B94B1AFD21CD38B400FF1B72 /* CountryPickerViewController.swift in Sources */,
-				B94B1AFE21CD38B400FF1B72 /* Columbus.swift in Sources */,
+				B94B1AFE21CD38B400FF1B72 /* ColumbusMain.swift in Sources */,
 				B94B1AFF21CD38B400FF1B72 /* CountryView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -582,7 +582,7 @@
 				B933818725CDD4F200618FFD /* CountryPickerViewController+DisplayState.swift in Sources */,
 				B93D76DD23E4691300E41863 /* CustomSearchBar.swift in Sources */,
 				B9F878A021CD28EC00273F82 /* CountryPickerViewController.swift in Sources */,
-				B9F8789E21CD28EC00273F82 /* Columbus.swift in Sources */,
+				B9F8789E21CD28EC00273F82 /* ColumbusMain.swift in Sources */,
 				B9F8789F21CD28EC00273F82 /* CountryView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Columbus.xcodeproj/xcshareddata/xcschemes/Columbus-iOS.xcscheme
+++ b/Columbus.xcodeproj/xcshareddata/xcschemes/Columbus-iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1240"
+   LastUpgradeVersion = "1250"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Columbus.xcodeproj/xcshareddata/xcschemes/Columbus-tvOS.xcscheme
+++ b/Columbus.xcodeproj/xcshareddata/xcschemes/Columbus-tvOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1240"
+   LastUpgradeVersion = "1250"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Example/ColumbusExample.xcodeproj/xcshareddata/xcschemes/Columbus_iOS_Example.xcscheme
+++ b/Example/ColumbusExample.xcodeproj/xcshareddata/xcschemes/Columbus_iOS_Example.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1240"
+   LastUpgradeVersion = "1250"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Example/ColumbusExample.xcodeproj/xcshareddata/xcschemes/Columbus_tvOS_Example.xcscheme
+++ b/Example/ColumbusExample.xcodeproj/xcshareddata/xcschemes/Columbus_tvOS_Example.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1240"
+   LastUpgradeVersion = "1250"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 <a href="https://github.com/Blackjacx/columbus/actions?query=workflow%3ACI"><img alt="CI status" src="https://github.com/blackjacx/columbus/workflows/CI/badge.svg" /></a>
 <img alt="Github Current Release" src="https://img.shields.io/github/release/blackjacx/Columbus.svg" /> 
 <img alt="Cocoapods Platforms" src="https://img.shields.io/cocoapods/p/Columbus.svg"/>
-<img alt="Xcode 12.0+" src="https://img.shields.io/badge/Xcode-12.0%2B-blue.svg"/>
+<img alt="Xcode 12.5+" src="https://img.shields.io/badge/Xcode-12.5%2B-blue.svg"/>
 <img alt="iOS 11.0+" src="https://img.shields.io/badge/iOS-11.0%2B-blue.svg"/>
-<img alt="Swift 5.3+" src="https://img.shields.io/badge/Swift-5.3%2B-orange.svg"/>
+<img alt="Swift 5.4+" src="https://img.shields.io/badge/Swift-5.4%2B-orange.svg"/>
 <img alt="Github Repo Size" src="https://img.shields.io/github/repo-size/blackjacx/Columbus.svg" />
 <img alt="Github Code Size" src="https://img.shields.io/github/languages/code-size/blackjacx/Columbus.svg" />
 <img alt="Github Closed PR's" src="https://img.shields.io/github/issues-pr-closed/blackjacx/Columbus.svg" />
@@ -27,8 +27,6 @@ A country picker for iOS, tvOS ad watchOS with features you will only find distr
 - Select a country from the history of selected countries - `still in progress`
 
 ## Installation
-
-Columbus is compatible with `iOS 11` and higher and builds with `Xcode 11` and `Swift 5.3+`. 
 
 ### Carthage (recommended)
 

--- a/Source/Classes/ColumbusMain.swift
+++ b/Source/Classes/ColumbusMain.swift
@@ -1,5 +1,5 @@
 //
-//  Columbus.swift
+//  ColumbusMain.swift
 //  Columbus
 //
 //  Created by Stefan Herold on 22.06.18.
@@ -9,10 +9,10 @@
 import Foundation
 
 // swiftlint:disable:next convenience_type
-public final class Columbus {
+public final class ColumbusMain {
 
     public static let bundle: Bundle = {
-        let frameworkBundle = Bundle(for: Columbus.self)
+        let frameworkBundle = Bundle(for: ColumbusMain.self)
         let bundleName = "Resources.bundle"
         guard let bundleURL = frameworkBundle.resourceURL?.appendingPathComponent(bundleName) else {
             preconditionFailure("Bundle url nil!")
@@ -24,6 +24,6 @@ public final class Columbus {
     }()
 
     static func layoutConstraintId(_ suffix: String) -> String {
-        "\(Columbus.bundle.bundleIdentifier!).\(suffix)"
+        "\(ColumbusMain.bundle.bundleIdentifier!).\(suffix)"
     }
 }

--- a/Source/Classes/Country.swift
+++ b/Source/Classes/Country.swift
@@ -37,7 +37,7 @@ extension Country: Decodable {
     }
 
     public init(from decoder: Decoder) throws {
-        let bundle = Columbus.bundle
+        let bundle = ColumbusMain.bundle
         let container = try decoder.container(keyedBy: CodingKeys.self)
 
         isoCountryCode = try container.decode(String.self, forKey: .isoCountryCode)

--- a/Source/Classes/CountryCell.swift
+++ b/Source/Classes/CountryCell.swift
@@ -55,16 +55,16 @@ final class CountryCell: UITableViewCell {
 
     func setupLayoutConstraints() {
         let leading = countryView.leadingAnchor.constraint(equalTo: contentView.layoutMarginsGuide.leadingAnchor)
-        leading.identifier = Columbus.layoutConstraintId("\(type(of: self)).leading")
+        leading.identifier = ColumbusMain.layoutConstraintId("\(type(of: self)).leading")
 
         let trailing = countryView.trailingAnchor.constraint(equalTo: contentView.layoutMarginsGuide.trailingAnchor)
-        trailing.identifier = Columbus.layoutConstraintId("\(type(of: self)).trailing")
+        trailing.identifier = ColumbusMain.layoutConstraintId("\(type(of: self)).trailing")
 
         let top = countryView.topAnchor.constraint(equalTo: contentView.layoutMarginsGuide.topAnchor)
-        top.identifier = Columbus.layoutConstraintId("\(type(of: self)).top")
+        top.identifier = ColumbusMain.layoutConstraintId("\(type(of: self)).top")
 
         let bottom = countryView.bottomAnchor.constraint(equalTo: contentView.layoutMarginsGuide.bottomAnchor)
-        bottom.identifier = Columbus.layoutConstraintId("\(type(of: self)).bottom")
+        bottom.identifier = ColumbusMain.layoutConstraintId("\(type(of: self)).bottom")
 
         NSLayoutConstraint.activate([leading, trailing, top, bottom])
     }

--- a/Source/Classes/CountryPickerViewController.swift
+++ b/Source/Classes/CountryPickerViewController.swift
@@ -192,39 +192,39 @@ public final class CountryPickerViewController: UIViewController {
         var constraints: [NSLayoutConstraint] = []
 
         tableViewBottomConstraint = table.bottomAnchor.constraint(equalTo: view.bottomAnchor)
-        tableViewBottomConstraint.identifier = Columbus.layoutConstraintId("\(type(of: self)).tableView.bottom")
+        tableViewBottomConstraint.identifier = ColumbusMain.layoutConstraintId("\(type(of: self)).tableView.bottom")
         constraints.append(tableViewBottomConstraint)
 
         let tableLeading = table.leadingAnchor.constraint(equalTo: view.leadingAnchor)
-        tableLeading.identifier = Columbus.layoutConstraintId("\(type(of: self)).tableView.leading")
+        tableLeading.identifier = ColumbusMain.layoutConstraintId("\(type(of: self)).tableView.leading")
         constraints.append(tableLeading)
 
         let tableTrailing = table.trailingAnchor.constraint(equalTo: view.trailingAnchor)
-        tableTrailing.identifier = Columbus.layoutConstraintId("\(type(of: self)).tableView.trailing")
+        tableTrailing.identifier = ColumbusMain.layoutConstraintId("\(type(of: self)).tableView.trailing")
         constraints.append(tableTrailing)
 
         #if os(iOS)
 
         let searchbarTop = searchbar.topAnchor.constraint(equalTo: view.topAnchor)
-        searchbarTop.identifier = Columbus.layoutConstraintId("\(type(of: self)).searchbar.top")
+        searchbarTop.identifier = ColumbusMain.layoutConstraintId("\(type(of: self)).searchbar.top")
         constraints.append(searchbarTop)
 
         let searchbarLeading = searchbar.leadingAnchor.constraint(equalTo: view.leadingAnchor)
-        searchbarLeading.identifier = Columbus.layoutConstraintId("\(type(of: self)).searchbar.leading")
+        searchbarLeading.identifier = ColumbusMain.layoutConstraintId("\(type(of: self)).searchbar.leading")
         constraints.append(searchbarLeading)
 
         let searchbarTrailing = searchbar.trailingAnchor.constraint(equalTo: view.trailingAnchor)
-        searchbarTrailing.identifier = Columbus.layoutConstraintId("\(type(of: self)).searchbar.trailing")
+        searchbarTrailing.identifier = ColumbusMain.layoutConstraintId("\(type(of: self)).searchbar.trailing")
         constraints.append(searchbarTrailing)
 
         let tableTop = table.topAnchor.constraint(equalTo: searchbar.bottomAnchor)
-        tableTop.identifier = Columbus.layoutConstraintId("\(type(of: self)).tableView.top")
+        tableTop.identifier = ColumbusMain.layoutConstraintId("\(type(of: self)).tableView.top")
         constraints.append(tableTop)
 
         #else
 
         let tableTop = table.topAnchor.constraint(equalTo: view.topAnchor)
-        tableTop.identifier = Columbus.layoutConstraintId("\(type(of: self)).tableView.top")
+        tableTop.identifier = ColumbusMain.layoutConstraintId("\(type(of: self)).tableView.top")
         constraints.append(tableTop)
 
         #endif
@@ -268,7 +268,7 @@ public final class CountryPickerViewController: UIViewController {
     private static func createCountries() -> CountryList {
 
         guard
-            let countriesFilePath = Columbus.bundle.path(forResource: "Countries", ofType: "json"),
+            let countriesFilePath = ColumbusMain.bundle.path(forResource: "Countries", ofType: "json"),
             let countriesData = FileManager.default.contents(atPath: countriesFilePath),
             let countries = try? JSONDecoder().decode(CountryList.self, from: countriesData) else {
                 return CountryList()

--- a/Source/Classes/CountryView.swift
+++ b/Source/Classes/CountryView.swift
@@ -86,7 +86,7 @@ final class CountryView: UIView {
 
         hStack.spacing = config.rasterSize
 
-        flagImageView.image = UIImage(named: country.isoCountryCode.lowercased(), in: Columbus.bundle, compatibleWith: nil)
+        flagImageView.image = UIImage(named: country.isoCountryCode.lowercased(), in: ColumbusMain.bundle, compatibleWith: nil)
 
         // Configure Display State
         switch config.displayState {

--- a/Source/Classes/CustomSearchBar.swift
+++ b/Source/Classes/CustomSearchBar.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-protocol CustomSearchBarDelegate: class {
+protocol CustomSearchBarDelegate: AnyObject {
     func searchBarTextDidChange(_ searchBar: CustomSearchBar, newText: String)
     func searchBarTextDidBeginEditing(_ searchBar: CustomSearchBar)
     func searchBarTextDidEndEditing(_ searchBar: CustomSearchBar)

--- a/Source/Classes/EmptyDecodable.swift
+++ b/Source/Classes/EmptyDecodable.swift
@@ -8,6 +8,4 @@
 
 import Foundation
 
-struct EmptyDecodable: Codable {
-    
-}
+struct EmptyDecodable: Codable { }

--- a/Source/Resources/Info.plist
+++ b/Source/Resources/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundleVersion</key>
 	<string>25</string>
 	<key>NSHumanReadableCopyright</key>
-	<string>Copyright © 2020 Stefan Herold. All rights reserved.</string>
+	<string>Copyright © 2021 Stefan Herold. All rights reserved.</string>
 	<key>NSPrincipalClass</key>
 	<string></string>
 </dict>


### PR DESCRIPTION
## Changes
- Allows the framework to be built with Carthage 0.38.0 using the command line `carthage build --platform iOS --cache-builds --use-xcframeworks` as xcframework and to be integrated in your project
- Rename Main class Columbus > ColumbusMain
- Update Copyrights
- Resolve Xcode recommended warnings