### PR TITLE
Fix Separator Alignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,12 @@
 # Change Log
 
 ## [Unreleased]
+* [#38](https://github.com/Blackjacx/Columbus/pull/38): Fix Separator Alignment - [@Blackjacx](https://github.com/Blackjacx).
 
-## [1.7.0] - 2021-11-23Z
+## [1.7.0] - 2021-11-23
 * [#37](https://github.com/Blackjacx/Columbus/pull/37): Replace images by emojis - [@Blackjacx](https://github.com/Blackjacx).
 
-## [1.6.0] - 2021-05-20Z
+## [1.6.0] - 2021-05-20
 * [#34](https://github.com/Blackjacx/Columbus/pull/34): XCFramework Compatibility - [@Blackjacx](https://github.com/Blackjacx).
 * Simplify section index creation - [@Blackjacx](https://github.com/Blackjacx).
 * Throw error instead of ignore missing flag icon - [@Blackjacx](https://github.com/Blackjacx).

--- a/Example/Source/AppDelegate.swift
+++ b/Example/Source/AppDelegate.swift
@@ -62,7 +62,7 @@ struct CountryPickerConfig: Configurable {
     var lineColor: UIColor = .line
     var lineWidth: CGFloat = 1.0 / UIScreen.main.scale
     var rasterSize: CGFloat = 10.0
-    var separatorInsets: NSDirectionalEdgeInsets? { .zero }
+    var separatorInsets: NSDirectionalEdgeInsets? { nil }
     let searchBarAttributedPlaceholder: NSAttributedString = {
         NSAttributedString(string: "Search",
                            attributes: [

--- a/Example/Source/AppDelegate.swift
+++ b/Example/Source/AppDelegate.swift
@@ -62,9 +62,7 @@ struct CountryPickerConfig: Configurable {
     var lineColor: UIColor = .line
     var lineWidth: CGFloat = 1.0 / UIScreen.main.scale
     var rasterSize: CGFloat = 10.0
-    var separatorInsets: UIEdgeInsets {
-        UIEdgeInsets(top: 0, left: rasterSize * 4.7, bottom: 0, right: rasterSize * 2.5)
-    }
+    var separatorInsets: NSDirectionalEdgeInsets? { .zero }
     let searchBarAttributedPlaceholder: NSAttributedString = {
         NSAttributedString(string: "Search",
                            attributes: [

--- a/Source/Classes/Configurable.swift
+++ b/Source/Classes/Configurable.swift
@@ -17,7 +17,7 @@ public protocol Configurable {
     var lineWidth: CGFloat { get }
     var rasterSize: CGFloat { get }
     var backgroundColor: UIColor { get }
-    var separatorInsets: UIEdgeInsets { get }
+    var separatorInsets: NSDirectionalEdgeInsets? { get }
     var controlColor: UIColor { get }
     var searchBarAttributedPlaceholder: NSAttributedString { get }
 }

--- a/Source/Classes/CountryPickerViewController.swift
+++ b/Source/Classes/CountryPickerViewController.swift
@@ -122,7 +122,7 @@ public final class CountryPickerViewController: UIViewController {
         #if os(iOS)
         setupSearchbar()
         #endif
-        setupLayoutConstraints()
+        setupAutoLayout()
 
         reloadData()
         displaySelectedCountry()
@@ -187,7 +187,7 @@ public final class CountryPickerViewController: UIViewController {
         view.addSubview(searchbar)
     }
 
-    private func setupLayoutConstraints() {
+    private func setupAutoLayout() {
 
         var constraints: [NSLayoutConstraint] = []
 
@@ -422,7 +422,7 @@ extension CountryPickerViewController: UITableViewDelegate {
 
         #if os(iOS)
         // setting seperator inset
-        cell.separatorInset = config.separatorInsets
+        cell.separatorInset = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: .greatestFiniteMagnitude)
         #endif
     }
 }

--- a/Source/Classes/CountryView.swift
+++ b/Source/Classes/CountryView.swift
@@ -10,10 +10,13 @@ import UIKit
 
 final class CountryView: UIView {
 
-    let hStack = UIStackView()
-    let flagIconView = UILabel()
-    let countryNameLabel = UILabel()
-    let countryCodeLabel = UILabel()
+    private (set) lazy var leadingTextAnchor: NSLayoutXAxisAnchor = countryNameLabel.leadingAnchor
+    private (set) lazy var trailingTextAnchor: NSLayoutXAxisAnchor = countryCodeLabel.trailingAnchor
+
+    private let hStack = UIStackView()
+    private let flagIconView = UILabel()
+    private let countryNameLabel = UILabel()
+    private let countryCodeLabel = UILabel()
 
     var country: Country!
     var config: Configurable!
@@ -23,7 +26,7 @@ final class CountryView: UIView {
         setupFlagIconView()
         setupCountryNameLabel()
         setupCountryCodeLabel()
-        setupViewLayoutConstraints()
+        setupAutoLayout()
     }
 
     override init(frame: CGRect) {
@@ -64,7 +67,7 @@ final class CountryView: UIView {
         countryCodeLabel.setContentHuggingPriority(.required, for: .vertical)
     }
 
-    func setupViewLayoutConstraints() {
+    func setupAutoLayout() {
         let constraints: [NSLayoutConstraint] = [
             hStack.leadingAnchor.constraint(equalTo: leadingAnchor),
             hStack.trailingAnchor.constraint(equalTo: trailingAnchor),


### PR DESCRIPTION
Separators where not aligned with the leading of the country text and
the trailing of the code label. By disabling the native separator and
adding a custom separator view it is now possible to configure this
from outside.

Now it looks like below - separators nicely aligned with leading/trailing of the labels and the best it automatically adjusts with increasing/decreasing font size.


![all-gradient](https://user-images.githubusercontent.com/794372/143282047-262dc445-15c8-4fff-9702-a57997d58841.png)

