### PR TITLE
Fix Icon Truncation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Change Log
 
 ## [Unreleased]
+* [#39](https://github.com/Blackjacx/Columbus/pull/39): Fix Icon Truncation - [@Blackjacx](https://github.com/Blackjacx).
 
-## [1.7.1] - 2021-11-24Z
+## [1.7.1] - 2021-11-24
 * [#38](https://github.com/Blackjacx/Columbus/pull/38): Fix Separator Alignment - [@Blackjacx](https://github.com/Blackjacx).
 
 ## [1.7.0] - 2021-11-23

--- a/Source/Classes/CountryView.swift
+++ b/Source/Classes/CountryView.swift
@@ -52,6 +52,7 @@ final class CountryView: UIView {
         flagIconView.numberOfLines = 1
         flagIconView.setContentHuggingPriority(.required, for: .horizontal)
         flagIconView.setContentHuggingPriority(.required, for: .vertical)
+        flagIconView.setContentCompressionResistancePriority(.required, for: .horizontal)
     }
 
     func setupCountryNameLabel() {
@@ -72,9 +73,7 @@ final class CountryView: UIView {
             hStack.leadingAnchor.constraint(equalTo: leadingAnchor),
             hStack.trailingAnchor.constraint(equalTo: trailingAnchor),
             hStack.topAnchor.constraint(equalTo: topAnchor),
-            hStack.bottomAnchor.constraint(equalTo: bottomAnchor),
-
-            flagIconView.widthAnchor.constraint(equalTo: flagIconView.heightAnchor)
+            hStack.bottomAnchor.constraint(equalTo: bottomAnchor)
         ]
         NSLayoutConstraint.activate(constraints)
     }
@@ -107,10 +106,8 @@ final class CountryView: UIView {
 
         // Configure Display State
         switch config.displayState {
-        case .simple:
-            countryCodeLabel.isHidden = true
-        case .countryCodeSelection:
-            countryCodeLabel.isHidden = false
+        case .simple:                   countryCodeLabel.isHidden = true
+        case .countryCodeSelection:     countryCodeLabel.isHidden = false
         }
     }
 }


### PR DESCRIPTION
Flag icons where truncated on the right side when the font was very
small. A horizontal compression resistancy priority fixed that.