### PR TITLE
Use system font for flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change Log
 
 ## [Unreleased]
+* [#40](https://github.com/Blackjacx/Columbus/pull/40): Use system font for flags - [@Blackjacx](https://github.com/Blackjacx).
 
 ## [1.7.2] - 2021-11-24Z
 * [#39](https://github.com/Blackjacx/Columbus/pull/39): Fix Icon Truncation - [@Blackjacx](https://github.com/Blackjacx).

--- a/Source/Classes/CountryView.swift
+++ b/Source/Classes/CountryView.swift
@@ -101,6 +101,10 @@ final class CountryView: UIView {
         paragraphStyle.alignment = .center
         attributes[.paragraphStyle] = paragraphStyle
 
+        // Ensure a system font is used for the emojis so they are not
+        // truncated or rendered in a weird way
+        attributes[.font] = UIFont.preferredFont(forTextStyle: .body)
+
         flagIconView.attributedText = NSAttributedString(string: country.flagString,
                                                          attributes: attributes)
 


### PR DESCRIPTION
Ensure a system font is used for the emojis so they are not truncated 
or rendered in a weird way.