### PR TITLE
Add fallback for CTCarrier deprecation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+* [#48](https://github.com/Blackjacx/Columbus/pull/48): Add fallback for CTCarrier deprecation - [@mic-ioki](https://github.com/mic-ioki).
+
 ## [1.8.0] - 2023-05-02Z
 * Remove auto assign to project workflow - [@Blackjacx](https://github.com/Blackjacx).
 * Make CoreTelephony Approach Debuggable - [@Blackjacx](https://github.com/Blackjacx).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,6 @@
 # Change Log
 
 ## [Unreleased]
-
 * [#48](https://github.com/Blackjacx/Columbus/pull/48): Add fallback for CTCarrier deprecation - [@mic-ioki](https://github.com/mic-ioki).
 
 ## [1.8.0] - 2023-05-02Z

--- a/Source/Classes/CountryPickerViewController.swift
+++ b/Source/Classes/CountryPickerViewController.swift
@@ -266,15 +266,23 @@ public final class CountryPickerViewController: UIViewController {
         // Core Telephony Approach
 
         #if os(iOS) && !targetEnvironment(simulator)
-        guard let cellularProviders = CTTelephonyNetworkInfo().serviceSubscriberCellularProviders else {
-            return defaultCountry
+
+        // CTCarrier is deprecated from 16.4 and Locale region is used as fallback.
+        // see: https://developer.apple.com/documentation/ios-ipados-release-notes/ios-ipados-16_4-release-notes#Deprecations
+
+        var deviceIsoCountryCode: String?
+        if #available(iOS 16.4, *) {
+            deviceIsoCountryCode = Locale.current.language.region?.identifier
+        } else {
+            guard let cellularProviders = CTTelephonyNetworkInfo().serviceSubscriberCellularProviders else {
+                return defaultCountry
+            }
+            let carriers = cellularProviders.map(\.value)
+            deviceIsoCountryCode = carriers.compactMap(\.isoCountryCode).first?.uppercased()
         }
-        let carriers = cellularProviders.map(\.value)
-        
-        guard let firstIsoCountryCode = carriers.compactMap(\.isoCountryCode).first?.uppercased() else {
-            return defaultCountry
-        }
-        guard let country = (countries.first { $0.isoCountryCode.compare(firstIsoCountryCode, options: .caseInsensitive) == .orderedSame }) else {
+
+        guard let deviceIsoCountryCode,
+              let country = (countries.first { $0.isoCountryCode.compare(deviceIsoCountryCode, options: .caseInsensitive) == .orderedSame }) else {
             return defaultCountry
         }
         return country


### PR DESCRIPTION
# Changes
Use Locale region identifier for iOS 16.4 later and CoreTelephony for earlier.

# Issues
- Resolve https://github.com/Blackjacx/Columbus/issues/47

# How To Test
- Run `CountryPickerViewController.defaultCountry()` on:
	- 	Device with iOS > 16.4, return value should be equal to device setting's region.
	-  Device with iOS < 16.4, return value should be equal to device's sim country.
