### PR TITLE
Make font attributes optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change Log
 
 ## [Unreleased]
+* [#51](https://github.com/Blackjacx/Columbus/pull/51): Make font attributes optional - [@Blackjacx](https://github.com/Blackjacx).
 
 ## [1.9.0] - 2023-05-09Z
 * [#49](https://github.com/Blackjacx/Columbus/pull/49): Add fallback for CTCarrier deprecation - [@mic-ioki](https://github.com/mic-ioki).

--- a/Example/Source/AppDelegate.swift
+++ b/Example/Source/AppDelegate.swift
@@ -59,6 +59,7 @@ struct CountryPickerConfig: Configurable {
             .font: UIFont.preferredFont(forTextStyle: .body)
         ]
     }
+    var searchTextAttributes: [NSAttributedString.Key: Any]? { textAttributes }
     var backgroundColor: UIColor = .background
     var selectionColor: UIColor = .selection
     var controlColor: UIColor = UIColor(red: 1.0 / 255.0, green: 192.0 / 255.0, blue: 1, alpha: 1)
@@ -66,7 +67,7 @@ struct CountryPickerConfig: Configurable {
     var lineWidth: CGFloat = 1.0 / UIScreen.main.scale
     var rasterSize: CGFloat = 10.0
     var separatorInsets: NSDirectionalEdgeInsets? { nil }
-    let searchBarAttributedPlaceholder: NSAttributedString = {
+    let searchBarAttributedPlaceholder: NSAttributedString? = {
         NSAttributedString(string: "Search",
                            attributes: [
                             .foregroundColor: UIColor.placeholder,

--- a/Source/Classes/Configurable.swift
+++ b/Source/Classes/Configurable.swift
@@ -11,6 +11,7 @@ import UIKit
 public protocol Configurable {
     var displayState: CountryPickerViewController.DisplayState { get }
     var textAttributes: [NSAttributedString.Key: Any] { get }
+    var searchTextAttributes: [NSAttributedString.Key: Any]? { get }
     var selectionColor: UIColor { get }
     var lineColor: UIColor { get }
     var lineWidth: CGFloat { get }
@@ -18,5 +19,5 @@ public protocol Configurable {
     var backgroundColor: UIColor { get }
     var separatorInsets: NSDirectionalEdgeInsets? { get }
     var controlColor: UIColor { get }
-    var searchBarAttributedPlaceholder: NSAttributedString { get }
+    var searchBarAttributedPlaceholder: NSAttributedString? { get }
 }

--- a/Source/Classes/CountryPickerViewController.swift
+++ b/Source/Classes/CountryPickerViewController.swift
@@ -133,9 +133,14 @@ public final class CountryPickerViewController: UIViewController {
         //
         // Don't move that to viewDidAppear to not produce a visible change.
         #if os(iOS)
-        searchController.searchBar.searchTextField.attributedPlaceholder = config.searchBarAttributedPlaceholder
-        searchController.searchBar.searchTextField.typingAttributes = config.textAttributes
-        searchController.searchBar.searchTextField.defaultTextAttributes = config.textAttributes
+        if let placeholder = config.searchBarAttributedPlaceholder {
+            searchController.searchBar.searchTextField.attributedPlaceholder = placeholder
+        }
+
+        if let textAttributes = config.searchTextAttributes {
+            searchController.searchBar.searchTextField.typingAttributes = textAttributes
+            searchController.searchBar.searchTextField.defaultTextAttributes = textAttributes
+        }
         #endif
     }
 


### PR DESCRIPTION
Certain views from Apple (e.g. UISearchController's search bar) react a bit, lets say allergic, when the font is changed. Therefore I hereby open up the possibility to opt out of setting the font attributes for the search bar and go with the defaults.